### PR TITLE
Update links to PS course homework

### DIFF
--- a/ps.html
+++ b/ps.html
@@ -112,14 +112,14 @@ pentru a lucra online în caiet.
 
 <p style="margin-left: 20px"/>
 <ol>
-<li><a href="ps/ps-tema-1.ipynb">Note muzicale</a>
-(<a href="https://nbviewer.ipython.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-tema-1.ipynb">vizualizare</a>)
+<li><a href="ps/ps-tema-1.ipynb" download>Note muzicale</a>
+(<a href="https://nbviewer.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-tema-1.ipynb">vizualizare</a>)
 </li>
-<li><a href="ps/ps-tema-2.ipynb">Prelucrarea imaginilor cu DFT</a>
-(<a href="https://nbviewer.ipython.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-tema-2.ipynb">vizualizare</a>)
+<li><a href="ps/ps-tema-2.ipynb" download>Prelucrarea imaginilor cu DFT</a>
+(<a href="https://nbviewer.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-tema-2.ipynb">vizualizare</a>)
 </li>
-<li><a href="ps/ps-tema-3.ipynb">Encoder JPEG</a>
-(<a href="https://nbviewer.ipython.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-tema-3.ipynb">vizualizare</a>)
+<li><a href="ps/ps-tema-3.ipynb" download>Encoder JPEG</a>
+(<a href="https://nbviewer.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-tema-3.ipynb">vizualizare</a>)
 </li>
 </ol>
 


### PR DESCRIPTION
- Adds the `download` attribute to the `.ipynb` links, in order to trigger a download of the respective files (some students were confused when their browsers opened the Jupyter notebooks as raw JSON files).
- Updates the nbviewer links so that they work again.