### PR TITLE
Fix nbviewer link to PS laboratory 1 exercises notebook

### DIFF
--- a/ps.html
+++ b/ps.html
@@ -135,7 +135,7 @@ sau
 
 <p style="margin-left: 20px"/>
 <ol>
-<li><a href="ps/ps-lab-1.pdf">Introducere</a> &mdash; <a href="ps/ps-lab-1-exerciții.ipynb">Exerciții</a> (<a href="https://nbviewer.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-lab1-exerciții.ipynb" target="_blank" rel="noopener noreferer">vizualizare</a>)</li>
+<li><a href="ps/ps-lab-1.pdf">Introducere</a> &mdash; <a href="ps/ps-lab-1-exerciții.ipynb">Exerciții</a> (<a href="https://nbviewer.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-lab-1-exerciții.ipynb" target="_blank" rel="noopener noreferer">vizualizare</a>)</li>
 <!--
 <li><a href="ps/ps-lab-2.pdf">Prelucrarea semnalelor în domeniul timp</a></li>
 <li><a href="ps/ps-lab-3.pdf">Prelucrarea semnalelor în domeniul frecvenței</a></li>


### PR DESCRIPTION
I've noticed that the preview link for the PS laboratory 1 exercises notebook doesn't work, due to a typo.