### PR TITLE
Fix small typo in PS lab 2 exercises

### DIFF
--- a/ps/ps-lab-2-exerciții.ipynb
+++ b/ps/ps-lab-2-exerciții.ipynb
@@ -135,8 +135,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "1. Afișați grafic semnalul inițial și cel decimat și comentați\n",
-        "diferențele."
+        "1. Afișați grafic semnalul inițial și cel decimat și comentați diferențele."
       ],
       "metadata": {
         "id": "U6y4SSByfTZz"


### PR DESCRIPTION
This PR removes a little extra newline in the `ps-lab-2-exerciții.ipynb` file that was bugging me out.