### PR TITLE
Add missing link to PS laboratory 6 material

### DIFF
--- a/ps.html
+++ b/ps.html
@@ -158,10 +158,10 @@ Dacă nu sunteți familiari cu ele, puteți începe prin a parcurge
  <li><a href="ps/ps-lab-5-guitar.wav">Guitar</a></li>
  <li><a href="ps/ps-lab-5-bass.wav">Bass</a></li>
 </ol>
-<!--
 </li>
-<li><a href="ps/ps-lab-6.pdf">Transformata Fourier. Partea I</a></li>
-<li><a href="ps/ps-lab-7.pdf">Transformata Fourier. Partea a II-a</a></li>
+<li><a href="ps/ps-lab-6.pdf">Transformata Fourier &mdash; Teorie</a> &mdash; <a href="ps/ps-lab-6-exerciții.ipynb" download>Exerciții</a> (<a href="https://nbviewer.org/github/pirofti/cs.unibuc.ro/blob/master/ps/ps-lab-6-exerciții.ipynb" target="_blank" rel="noopener noreferer">vizualizare</a>)</li>
+<!--
+<li><a href="ps/ps-lab-7.pdf">Transformata Fourier &mdash Aplicații</a></li>
 <li><a href="ps/ps-lab-8.pdf">Convoluție. Filtre</a></li>
 <li><a href="ps/ps-lab-9.pdf">Antrenarea dicționarelor</a></li>
 -->


### PR DESCRIPTION
I accidentally forgot to update the PS web page to also display a link to the materials for lab 6.