### PR TITLE
Fix extraneous backslash in PS lab 6 problem statement

### DIFF
--- a/ps/ps-lab-6-exerciții.ipynb
+++ b/ps/ps-lab-6-exerciții.ipynb
@@ -1,1 +1,89 @@
-{"nbformat":4,"nbformat_minor":0,"metadata":{"colab":{"provenance":[],"authorship_tag":"ABX9TyOhfIWxUvhV4lICKA8zgvI8"},"kernelspec":{"name":"python3","display_name":"Python 3"},"language_info":{"name":"python"}},"cells":[{"cell_type":"markdown","source":["# Laboratorul 6\n","\n","Rezolvați exercițiile de mai jos în celulele care v-au fost puse la dispoziție. La final, rulați tot notebook-ul și asigurați-vă că nu aveți erori. Salvați fișierul și încărcați-l în assignment-ul de Teams corespunzător grupei voastre."],"metadata":{"id":"Yyyeym-VC3Bq"}},{"cell_type":"code","source":["import math\n","import numpy as np\n","import matplotlib.pyplot as plt"],"metadata":{"id":"KUu8KcQ_BAXh"},"execution_count":null,"outputs":[]},{"cell_type":"markdown","source":["## Exercițiul 1\n","\n","Realizați graficele din figurile 1 și 2 din îndrumar pentru un semnal sinusoidal cu o frecvență aleasă de voi, _alta_ decât cea utilizată aici.\n","\n","Reamintim că graficul din dreapta din figura 1 reprezintă înfășurarea semnalului pe cercul unitate, anume reprezentarea în planul complex a șirului $y[n] = x[n] \\cdot e^{-2 \\pi i n}$.\n","\n","De asemenea, figura 2 arată influența diferitelor frecvențe de înfășurare asupra formei pe care o are această reprezentare. \\\\\n","Afișați grafic $z[\\omega] = x[n] \\cdot e^{-2 \\pi i \\omega n}$, pentru **patru valori diferite** ale $\\omega$, dintre care una egală cu frecvența semnalului."],"metadata":{"id":"qTj85twMC6Wq"}},{"cell_type":"code","execution_count":null,"metadata":{"id":"FE8l8HUyCwig"},"outputs":[],"source":[]},{"cell_type":"markdown","source":["## Exercițiul 2\n","\n","Afișați **modulul** (valoarea absolută) a transformatei Fourier (folosind relația 1 din PDF) pentru un semnal compus de voi, având **cel puțin trei componente de frecvență distincte** (obțineți un grafic asemănător figurii 3).\n","\n","Ajustați frecvențele de înfășurare $\\omega$ utilizate în transformata Fourier în funcție de frecvența caracteristică a sinusoidei."],"metadata":{"id":"iqjUTeNSDX16"}},{"cell_type":"code","source":[],"metadata":{"id":"XVsXxaqXDkIw"},"execution_count":null,"outputs":[]}]}
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Laboratorul 6\n",
+        "\n",
+        "Rezolvați exercițiile de mai jos în celulele care v-au fost puse la dispoziție. La final, rulați tot notebook-ul și asigurați-vă că nu aveți erori. Salvați fișierul și încărcați-l în assignment-ul de Teams corespunzător grupei voastre."
+      ],
+      "metadata": {
+        "id": "Yyyeym-VC3Bq"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import math\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt"
+      ],
+      "metadata": {
+        "id": "KUu8KcQ_BAXh"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Exercițiul 1\n",
+        "\n",
+        "Realizați graficele din figurile 1 și 2 din îndrumar pentru un semnal sinusoidal cu o frecvență aleasă de voi, _alta_ decât cea utilizată aici.\n",
+        "\n",
+        "Reamintim că graficul din dreapta din figura 1 reprezintă înfășurarea semnalului pe cercul unitate, anume reprezentarea în planul complex a șirului $y[n] = x[n] \\cdot e^{-2 \\pi i n}$.\n",
+        "\n",
+        "De asemenea, figura 2 arată influența diferitelor frecvențe de înfășurare asupra formei pe care o are această reprezentare. \\\n",
+        "Afișați grafic $z[\\omega] = x[n] \\cdot e^{-2 \\pi i \\omega n}$, pentru **patru valori diferite** ale $\\omega$, dintre care una egală cu frecvența semnalului."
+      ],
+      "metadata": {
+        "id": "qTj85twMC6Wq"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "FE8l8HUyCwig"
+      },
+      "outputs": [],
+      "source": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Exercițiul 2\n",
+        "\n",
+        "Afișați **modulul** (valoarea absolută) a transformatei Fourier (folosind relația 1 din PDF) pentru un semnal compus de voi, având **cel puțin trei componente de frecvență distincte** (obțineți un grafic asemănător figurii 3).\n",
+        "\n",
+        "Ajustați frecvențele de înfășurare $\\omega$ utilizate în transformata Fourier în funcție de frecvența caracteristică a sinusoidei."
+      ],
+      "metadata": {
+        "id": "iqjUTeNSDX16"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "XVsXxaqXDkIw"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
There is a misplaced `\` left in an exercise statement in PS laboratory 6. It's not relevant for this academic year anymore, but it was nagging me.