### PR TITLE
Fix typo in PS lab 7 exercise set

### DIFF
--- a/ps/ps-lab-7-exerciții.ipynb
+++ b/ps/ps-lab-7-exerciții.ipynb
@@ -104,7 +104,7 @@
         "\n",
         "Utilizați funcția `np.fft.rfft(x)` pentru a calcula **transformata Fourier** a semnalului și afișați grafic **modulul transformatei**.\n",
         "\n",
-        "Deoarece valorile pe care le veți calcula sunt în Hz, este important să definiți corect frecvența de eșantionare (astfel încât valorile de frecvențe pe care le obțineți utilizând ultima secvență de cod din ghidul Python din ]îndrumar să aibă o interpretare corectă din punct de vedere fizic)."
+        "Deoarece valorile pe care le veți calcula sunt în Hz, este important să definiți corect frecvența de eșantionare (astfel încât valorile de frecvențe pe care le obțineți utilizând ultima secvență de cod din ghidul Python din îndrumar să aibă o interpretare corectă din punct de vedere fizic)."
       ],
       "metadata": {
         "id": "R9SF1hBg9Qia"


### PR DESCRIPTION
Another small typo in the PS exercises, this time a randomly misplaced `]`.